### PR TITLE
Updating 'quickest runs' leaderboard label

### DIFF
--- a/resources/views/leaderboard.blade.php
+++ b/resources/views/leaderboard.blade.php
@@ -144,7 +144,7 @@
                     <thead>
                     <tr>
                         <th>Character</th>
-                        <th class="text-right">Average loot/run</th>
+                        <th class="text-right">Average run speed</th>
                     </tr>
                     @forelse($rtsloot_leaderboard_90 as $l)
                         @component("components.leaderboard_char_rts", ['item' => $l])@endcomponent
@@ -164,7 +164,7 @@
                     <thead>
                     <tr>
                         <th>Character</th>
-                        <th class="text-right">Average loot/run</th>
+                        <th class="text-right">Average run speed</th>
                     </tr>
                     @forelse($rtsloot_leaderboard_30 as $l)
                         @component("components.leaderboard_char_rts", ['item' => $l])@endcomponent
@@ -184,7 +184,7 @@
                     <thead>
                     <tr>
                         <th>Character</th>
-                        <th class="text-right">Average loot/run</th>
+                        <th class="text-right">Average run speed</th>
                     </tr>
                     @forelse($rtsloot_leaderboard_07 as $l)
                         @component("components.leaderboard_char_rts", ['item' => $l])@endcomponent


### PR DESCRIPTION
Currently the 'quickest runs on average' leaderboard uses 'Average loot/run' as a heading, but the data below that heading reflects average run times, not loot.  This PR updates the heading to better reflect the accompanying data.  